### PR TITLE
Release 4.0.1: Windows CI fix + auto-update fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os:
           [
-            { name: 'windows', image: 'windows-latest' },
+            { name: 'windows', image: 'windows-2022' },
             { name: 'linux', image: 'ubuntu-latest' },
             { name: 'macos', image: 'macos-latest' }
           ]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "todo-today",
   "productName": "Todo Today",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "The todo List for the easily distracted",
   "main": ".vite/build/main.js",
   "scripts": {
@@ -17,7 +17,7 @@
   "keywords": [],
   "repository": {
     "type": "git",
-    "url": "https://github.com/TravisBumgarner/todo-today.git"
+    "url": "https://github.com/travisbumgarner/todo-today.git"
   },
   "author": {
     "name": "Travis Bumgarner",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,8 +1,8 @@
+import path from 'node:path'
 import { app, BrowserWindow, Menu, nativeImage, shell, Tray } from 'electron'
 import log from 'electron-log/main'
 import started from 'electron-squirrel-startup'
-import path from 'node:path'
-import { updateElectronApp } from 'update-electron-app'
+import { UpdateSourceType, updateElectronApp } from 'update-electron-app'
 import { isDev, isMac } from './config'
 import menu from './menu'
 import './messages/messages'
@@ -12,6 +12,14 @@ log.initialize()
 Menu.setApplicationMenu(menu)
 
 updateElectronApp({
+  // update.electronjs.org matches the owner/repo path case-sensitively and only
+  // serves the all-lowercase form. Inferring the repo from package.json's
+  // repository URL yields "TravisBumgarner/todo-today", which the service answers
+  // with 204 (no update) — silently breaking auto-update. Pin the lowercase path.
+  updateSource: {
+    type: UpdateSourceType.ElectronPublicUpdateService,
+    repo: 'travisbumgarner/todo-today',
+  },
   logger: {
     log: log.log,
     info: log.info,

--- a/src/shared/changelog.ts
+++ b/src/shared/changelog.ts
@@ -8,12 +8,16 @@ export interface ChangelogEntry {
 }
 export const CHANGELOG: ChangelogEntry[] = [
   {
-    version: '4.0.0',
+    version: '4.0.1',
     date: '2026-07-24',
     changes: [
       {
         category: 'Improved',
         description: 'Overhauled the user interface',
+      },
+      {
+        category: 'Fixed',
+        description: 'Automatic updates were not being detected',
       },
     ],
   },


### PR DESCRIPTION
Re-lands the release fixes that missed main. PR #126 was squash-merged while it only contained the 4.0.0 version bump, so the commits pushed afterward (Windows CI pin, auto-update fix, 4.0.1 bump) never reached main — which is why the release workflow on main still fails on Windows with the VS 18 / node-gyp error.

## Changes
- **Windows CI fix** — pin the Windows release runner to `windows-2022`. `windows-latest` now provisions Visual Studio 18, which the node-gyp bundled in `@electron/node-gyp` rejects (`unsupported version: 18`), then fails its VSSetup fallback with `ERR_CHILD_PROCESS_STDIO_MAXBUFFER`, breaking `better-sqlite3`'s native build during `npm ci`.
- **Auto-update fix** — pin `update-electron-app`'s source to lowercase `travisbumgarner/todo-today` and lowercase `package.json`'s repository URL. `update.electronjs.org` matches the owner/repo path case-sensitively and answered the capitalized `TravisBumgarner/todo-today` request with HTTP 204, silently breaking auto-update for every version.
- **Version bump** `4.0.0` → `4.0.1` (`npm run check-version` passes). 4.0.0 shipped with the broken updater, so the fix goes out as 4.0.1.

## ⚠️ Notes
- The Windows job has `continue-on-error: true`, so the overall run reports **success even when Windows fails** — check the per-job result.
- All existing installs (3.3.0 and 4.0.0) carry the broken updater and will **not** auto-update to 4.0.1; those users must install 4.0.1 manually once. Auto-update works from 4.0.1 onward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)